### PR TITLE
UPSTREAM: <carry>: Bump golang version for linters

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: golang-1.17
+  tag: rhel-8-release-golang-1.19-openshift-4.12


### PR DESCRIPTION
Currently upstream requires v1.19, so to pass tests we need to bump the version in our CI.
